### PR TITLE
cleans up quotes and semis to pass linting when running gulp

### DIFF
--- a/app/scripts/famousAngularStarter.js
+++ b/app/scripts/famousAngularStarter.js
@@ -8,11 +8,11 @@ angular.module('famousAngularStarter',
   .config(function ($stateProvider, $urlRouterProvider) {
     $stateProvider
       .state('home', {
-        url: "/",
+        url: '/',
         templateUrl: 'partials/main.html',
         controller: 'MainCtrl'
       });
 
-    $urlRouterProvider.otherwise("/");
+    $urlRouterProvider.otherwise('/');
   })
 ;

--- a/app/scripts/main/main-ctrl.js
+++ b/app/scripts/main/main-ctrl.js
@@ -2,5 +2,5 @@
 
 angular.module('famousAngularStarter')
   .controller('MainCtrl', function ($scope) {
-    $scope.greeting = "Hello, Famo.us"
+    $scope.greeting = 'Hello, Famo.us';
   });

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,9 @@
     "angular-ui-router": "0.2.x",
     "angular-route": "1.2.x",
     "bootstrap-sass-official": "3.1.1",
-    "famous-angular": "~0.0.10"
+    "famous-angular": "~0.0.10",
+    "jquery": "~2.1.1",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "angular-mocks": "1.2.x"


### PR DESCRIPTION
Added missing dependency declarations to bower.json to resolve useref error thrown during gulp build.  Also, running gulp causes syntax alerts for strings enclosed in double-quotes and missing semi-colon.  Made a few corrections to resolve the issue.
