### PR TITLE
chore: 'npm install' automatically installs global cli

### DIFF
--- a/bin/prebublish.sh
+++ b/bin/prebublish.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+bash which bower || npm install -g bower
+bash which gulp || npm install -g gulp
+bash which karma || npm install -g karma-cli
+echo "prepublish executed sucessfully"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "require-dir": "~0.1.0"
   },
   "scripts": {
+    "prepublish": "bash ./bin/prepublish.sh",
     "install": "bower install",
     "start": "gulp watch"
   },


### PR DESCRIPTION
Using the prebublish entry in `package.json`, `npm install` will run `./bin/prebublish.sh` to automatically globally install the needed cli:
- gulp
- karma-cli
- bower

This simplifies the installation process of the starter kit
